### PR TITLE
feat: add theme toggle button with preference persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,12 @@
     <main>
       <div class="wrapper">
         <div class="flexbox">
-          <h1>The Not Very Useful Gaming Database</h1>
+          <div class="header-container">
+            <h1>The Not Very Useful Gaming Database</h1>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">
+              <span class="theme-toggle-text">🌙</span>
+            </button>
+          </div>
           <div class="search-container">
             <label for="search-input" class="search-label"
               >What do you wish to find?</label

--- a/script/script.js
+++ b/script/script.js
@@ -10,6 +10,64 @@ function toTitleCase(str) {
         .join(' ');
 }
 
+// Theme management
+const themeToggle = document.getElementById('theme-toggle');
+const themeToggleText = document.querySelector('.theme-toggle-text');
+const body = document.body;
+
+// Check for saved theme preference or default to system preference
+const getPreferredTheme = () => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+        return savedTheme;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+// Apply theme and update toggle button
+const setTheme = (theme) => {
+    // Remove existing theme classes
+    body.classList.remove('theme-light', 'theme-dark');
+    
+    if (theme === 'light') {
+        body.classList.add('theme-light');
+        themeToggleText.textContent = '☀️';
+        themeToggle.setAttribute('aria-label', 'Switch to dark mode');
+    } else {
+        body.classList.add('theme-dark');
+        themeToggleText.textContent = '🌙';
+        themeToggle.setAttribute('aria-label', 'Switch to light mode');
+    }
+    
+    localStorage.setItem('theme', theme);
+};
+
+// Initialize theme on page load
+const initializeTheme = () => {
+    const currentTheme = getPreferredTheme();
+    setTheme(currentTheme);
+};
+
+// Toggle theme
+const toggleTheme = () => {
+    const currentTheme = localStorage.getItem('theme') || getPreferredTheme();
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+};
+
+// Initialize theme
+initializeTheme();
+
+// Listen for system theme changes only if no manual preference is set
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (!localStorage.getItem('theme')) {
+        setTheme(e.matches ? 'dark' : 'light');
+    }
+});
+
+// Theme toggle event listener
+themeToggle.addEventListener('click', toggleTheme);
+
 const searchField = document.getElementById('search-input');
 const searchButton = document.getElementById('search-button');
 const randButton = document.getElementById('random-button');

--- a/styles/style.css
+++ b/styles/style.css
@@ -19,6 +19,35 @@ main {
     gap: 1rem;
 }
 
+.header-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.theme-toggle {
+    position: relative;
+    padding: 0.8rem 1.5rem;
+    font-family: "Press Start 2P", system-ui;
+    font-size: 1.2rem;
+    background-color: var(--retro-white-soft);
+    color: var(--retro-black);
+    border: 2px solid var(--retro-black);
+    cursor: pointer;
+    transition: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.theme-toggle:hover {
+    background-color: var(--retro-white);
+}
+
+.theme-toggle:active {
+    transform: translateY(1px);
+}
+
 .search-container {
     border: 3px solid var(--retro-black);
     padding: 2rem;
@@ -158,6 +187,21 @@ footer {
     .wrapper {
         padding: 0.5rem 0.5rem;
     }
+
+    .header-container {
+        justify-content: center;
+        text-align: center;
+    }
+
+    .header-container h1 {
+        flex: 1;
+        margin-bottom: 0.5rem;
+    }
+
+    .theme-toggle {
+        padding: 0.6rem 1.2rem;
+        font-size: 1rem;
+    }
 }
 
 @media (max-width: 440px) {
@@ -196,4 +240,99 @@ footer {
         border-bottom: 2px solid var(--retro-white);
         border-right: 2px solid var(--retro-white);
     }
+
+    .theme-toggle {
+        background-color: var(--retro-black);
+        color: var(--retro-white);
+        border: 2px solid var(--retro-white);
+    }
+
+    .theme-toggle:hover {
+        background-color: var(--button-edge-gray);
+    }
+}
+
+/* Manual theme overrides */
+.theme-light {
+    background-color: var(--retro-white) !important;
+    color: var(--retro-black) !important;
+}
+
+.theme-light .search-container {
+    border: 3px solid var(--retro-black) !important;
+}
+
+.theme-light .search-field {
+    border: 2px solid var(--retro-black) !important;
+}
+
+.theme-light .eight-bit-btn {
+    color: var(--retro-black) !important;
+}
+
+.theme-light .eight-bit-btn::after, 
+.theme-light .eight-bit-btn::before {
+    background-color: var(--retro-black) !important;
+}
+
+.theme-light .info-table {
+    border: 3px solid var(--retro-black) !important;
+}
+
+.theme-light th, 
+.theme-light td {
+    border-bottom: 2px solid var(--retro-black) !important;
+    border-right: 2px solid var(--retro-black) !important;
+}
+
+.theme-light .theme-toggle {
+    background-color: var(--retro-white-soft) !important;
+    color: var(--retro-black) !important;
+    border: 2px solid var(--retro-black) !important;
+}
+
+.theme-light .theme-toggle:hover {
+    background-color: var(--retro-white) !important;
+}
+
+.theme-dark {
+    background-color: var(--retro-black) !important;
+    color: var(--retro-white) !important;
+}
+
+.theme-dark .search-container {
+    border: 3px solid var(--retro-white) !important;
+}
+
+.theme-dark .search-field {
+    border: 2px solid var(--retro-white) !important;
+}
+
+.theme-dark .eight-bit-btn {
+    color: var(--button-text-gray) !important;
+}
+
+.theme-dark .eight-bit-btn::after, 
+.theme-dark .eight-bit-btn::before {
+    background-color: var(--button-edge-gray) !important;
+}
+
+.theme-dark .info-table {
+    border: 3px solid var(--retro-white) !important;
+}
+
+.theme-dark th, 
+.theme-dark td {
+    border-bottom: 2px solid var(--retro-white) !important;
+    border-right: 2px solid var(--retro-white) !important;
+}
+
+.theme-dark .theme-toggle {
+    background-color: var(--retro-black) !important;
+    color: var(--retro-white) !important;
+    border: 2px solid var(--retro-white) !important;
+}
+
+.theme-dark .theme-toggle:hover {
+    background-color: var(--button-edge-gray) !important;
 }


### PR DESCRIPTION
# Description

Adds a manual theme toggle button to allow users to override system color scheme preferences while maintaining backward compatibility with automatic theme detection.

# Changes Made

# 🎨 User Interface
- Added theme toggle button in the header with sun (☀️) and moon (🌙) emoji icons
- Button clearly indicates current active mode and switches accordingly
- Maintains retro 8-bit styling consistent with existing design language
- Responsive design that adapts to mobile screens

Closes: good-first issue regarding manual theme toggle implementation
